### PR TITLE
feat: add MPRIS support with loop/shuffle control and album art thumbnails

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/clipperhouse/uax29/v2 v2.5.0 h1:x7T0T4eTHDONxFJsL94uKNKPHrclyFI0lm7+w
 github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/internal/model/session.go
+++ b/internal/model/session.go
@@ -45,6 +45,7 @@ type Session struct {
 	PinArtists     bool              `json:"pin_artists"`      // keep artists expanded when unfocused
 	ArtistsCur     int               `json:"artists_cur"`      // cursor in artists panel
 	LoopTrack      bool              `json:"loop_track"`       // loop current track on EOF
+	LoopPlaylist   bool              `json:"loop_playlist"`    // loop entire playlist on EOF
 	LoopCount      int               `json:"loop_count"`       // remaining loops (0 = infinite)
 	LoopTotal      int               `json:"loop_total"`       // original loop count for display
 	Theme          map[string]string `json:"theme,omitempty"`  // custom color theme overrides

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -5,11 +5,12 @@ import "time"
 
 // Track represents a single music track.
 type Track struct {
-	ID        string
-	Title     string
-	Artist    string
-	Duration  time.Duration
-	StreamURL string
+	ID           string
+	Title        string
+	Artist       string
+	Duration     time.Duration
+	StreamURL    string
+	ThumbnailURL string
 }
 
 // PlayerState represents the current playback state.
@@ -27,4 +28,30 @@ type PlayerStatus struct {
 	Track    *Track
 	Position time.Duration
 	Volume   int // 0-100
+}
+
+type PlayerInterface interface {
+	Status() PlayerStatus
+	Play(t *Track)
+	Pause()
+	Stop()
+	Seek(deltaSec float64)
+	SeekAbsolute(sec float64)
+	SetVolume(v int)
+
+	// Shuffle state (set by TUI, queried by MPRIS)
+	SetShuffle(bool)
+	IsShuffle() bool
+
+	// Loop state (set by TUI, queried by MPRIS)
+	SetLoopTrack(bool)
+	IsLoopTrack() bool
+	SetLoopPlaylist(bool)
+	IsLoopPlaylist() bool
+
+	// MPRIS action channels
+	OnNext() chan struct{}
+	OnPrev() chan struct{}
+	OnSeek() chan int64
+	OnSetPosition() chan int64
 }

--- a/internal/mpris/mpris.go
+++ b/internal/mpris/mpris.go
@@ -1,0 +1,438 @@
+package mpris
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Sadoaz/vimyt/internal/model"
+	"github.com/godbus/dbus/v5"
+)
+
+const (
+	dbusName    = "org.mpris.MediaPlayer2.vimyt"
+	dbusPath    = "/org/mpris/MediaPlayer2"
+	ifacePlayer = "org.mpris.MediaPlayer2.Player"
+	ifaceRoot   = "org.mpris.MediaPlayer2"
+)
+
+type Server struct {
+	player   model.PlayerInterface
+	conn     *dbus.Conn
+	quit     context.CancelFunc
+	quitDone chan struct{}
+}
+
+func New(player model.PlayerInterface) (*Server, error) {
+	conn, err := dbus.ConnectSessionBus()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Server{
+		player:   player,
+		conn:     conn,
+		quit:     cancel,
+		quitDone: make(chan struct{}),
+	}
+
+	if err := s.export(); err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	if _, err := conn.RequestName(dbusName, dbus.NameFlagDoNotQueue); err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	go s.watchPlayback(ctx)
+
+	return s, nil
+}
+
+func (s *Server) export() error {
+	if err := s.conn.Export(s, dbusPath, ifaceRoot); err != nil {
+		return err
+	}
+	if err := s.conn.Export(s, dbusPath, ifacePlayer); err != nil {
+		return err
+	}
+
+	// Properties interface via ExportMethodTable (requires *dbus.Error return)
+	props := map[string]any{
+		"GetAll": s.getAllHandler,
+		"Get":    s.getHandler,
+		"Set":    s.setHandler,
+	}
+	return s.conn.ExportMethodTable(props, dbusPath, "org.freedesktop.DBus.Properties")
+}
+
+func (s *Server) Close() {
+	s.quit()
+	<-s.quitDone
+	if s.conn != nil {
+		s.conn.ReleaseName(dbusName)
+		s.conn.Close()
+	}
+}
+
+// --- org.mpris.MediaPlayer2.Root ---
+
+func (s *Server) Raise() *dbus.Error { return nil }
+
+func (s *Server) Quit() *dbus.Error {
+	close(s.quitDone)
+	s.quit()
+	return nil
+}
+
+// --- org.mpris.MediaPlayer2.Player ---
+
+func (s *Server) Next() *dbus.Error {
+	select {
+	case s.player.OnNext() <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (s *Server) Previous() *dbus.Error {
+	select {
+	case s.player.OnPrev() <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (s *Server) Pause() *dbus.Error {
+	s.player.Pause()
+	return nil
+}
+
+func (s *Server) Stop() *dbus.Error {
+	s.player.Stop()
+	return nil
+}
+
+func (s *Server) Play() *dbus.Error {
+	st := s.player.Status()
+	if st.Track != nil {
+		s.player.Play(st.Track)
+	}
+	return nil
+}
+
+func (s *Server) PlayPause() *dbus.Error {
+	s.player.Pause()
+	return nil
+}
+
+func (s *Server) Seek(offset int64) *dbus.Error {
+	select {
+	case s.player.OnSeek() <- offset:
+	default:
+	}
+	return nil
+}
+func (s *Server) SetPosition(o dbus.ObjectPath, pos int64) *dbus.Error {
+	select {
+	case s.player.OnSetPosition() <- pos:
+	default:
+	}
+	return nil
+}
+func (s *Server) OpenUri(string) *dbus.Error { return nil }
+
+// --- Property getters (return (value, *dbus.Error)) ---
+
+func (s *Server) GetPlaybackStatus() (string, *dbus.Error) {
+	st := s.player.Status().State
+	switch st {
+	case model.Playing:
+		return "Playing", nil
+	case model.Paused:
+		return "Paused", nil
+	default:
+		return "Stopped", nil
+	}
+}
+
+func (s *Server) GetLoopStatus() (string, *dbus.Error) {
+	if p, ok := s.player.(interface{ IsLoopPlaylist() bool }); ok && p.IsLoopPlaylist() {
+		return "Playlist", nil
+	}
+	if p, ok := s.player.(interface{ IsLoopTrack() bool }); ok && p.IsLoopTrack() {
+		return "Track", nil
+	}
+	return "None", nil
+}
+
+func (s *Server) GetRate() (float64, *dbus.Error) { return 1.0, nil }
+
+func (s *Server) GetShuffle() (bool, *dbus.Error) {
+	if p, ok := s.player.(interface{ IsShuffle() bool }); ok {
+		return p.IsShuffle(), nil
+	}
+	return false, nil
+}
+func (s *Server) GetMinimumRate() (float64, *dbus.Error) { return 1.0, nil }
+func (s *Server) GetMaximumRate() (float64, *dbus.Error) { return 1.0, nil }
+func (s *Server) GetCanPlay() (bool, *dbus.Error)        { return true, nil }
+func (s *Server) GetCanPause() (bool, *dbus.Error)       { return true, nil }
+func (s *Server) GetCanSeek() (bool, *dbus.Error)        { return true, nil }
+func (s *Server) GetCanGoNext() (bool, *dbus.Error)      { return true, nil }
+func (s *Server) GetCanGoPrevious() (bool, *dbus.Error)  { return true, nil }
+func (s *Server) GetCanControl() (bool, *dbus.Error)     { return true, nil }
+
+func (s *Server) GetVolume() (float64, *dbus.Error) {
+	return float64(s.player.Status().Volume) / 100.0, nil
+}
+
+func (s *Server) GetPosition() (int64, *dbus.Error) {
+	// time.Duration is nanoseconds, convert to microseconds
+	return int64(s.player.Status().Position) / 1000, nil
+}
+
+func artURL(t *model.Track) string {
+	if t.ThumbnailURL != "" {
+		return t.ThumbnailURL
+	}
+	if t.ID != "" {
+		return fmt.Sprintf("https://img.youtube.com/vi/%s/hqdefault.jpg", t.ID)
+	}
+	return ""
+}
+
+func (s *Server) GetMetadata() (map[string]dbus.Variant, *dbus.Error) {
+	st := s.player.Status()
+	if st.Track == nil {
+		return nil, nil
+	}
+	t := st.Track
+	m := map[string]dbus.Variant{
+		"mpris:trackid": dbus.MakeVariant(dbus.ObjectPath("/org/mpris/MediaPlayer2/TrackList/NoTrack")),
+		"xesam:title":   dbus.MakeVariant(t.Title),
+		"xesam:artist":  dbus.MakeVariant([]string{t.Artist}),
+		"mpris:artUrl":  dbus.MakeVariant(artURL(t)),
+	}
+	if t.Duration > 0 {
+		m["mpris:length"] = dbus.MakeVariant(uint64(t.Duration) / 1000)
+	}
+	return m, nil
+}
+
+// --- Property setters (return *dbus.Error) ---
+
+func (s *Server) SetVolume(v float64) *dbus.Error {
+	s.player.SetVolume(int(v * 100))
+	return nil
+}
+
+func (s *Server) SetLoopStatus(loop string) *dbus.Error {
+	setTrack := func(on bool) {
+		if p, ok := s.player.(interface{ SetLoopTrack(bool) }); ok {
+			p.SetLoopTrack(on)
+		}
+	}
+	setPlaylist := func(on bool) {
+		if p, ok := s.player.(interface{ SetLoopPlaylist(bool) }); ok {
+			p.SetLoopPlaylist(on)
+		}
+	}
+	switch loop {
+	case "Track":
+		setPlaylist(false)
+		setTrack(true)
+	case "Playlist":
+		setTrack(false)
+		setPlaylist(true)
+	default:
+		setPlaylist(false)
+		setTrack(false)
+	}
+	return nil
+}
+
+func (s *Server) SetRate(float64) *dbus.Error { return nil }
+
+func (s *Server) SetShuffle(on bool) *dbus.Error {
+	if p, ok := s.player.(interface{ SetShuffle(bool) }); ok {
+		p.SetShuffle(on)
+	}
+	return nil
+}
+
+// --- org.freedesktop.DBus.Properties handlers ---
+
+func (s *Server) getAllHandler(iface string) (map[string]dbus.Variant, *dbus.Error) {
+	st := s.player.Status()
+
+	var status string
+	switch st.State {
+	case model.Playing:
+		status = "Playing"
+	case model.Paused:
+		status = "Paused"
+	default:
+		status = "Stopped"
+	}
+
+	loopStatus, _ := s.GetLoopStatus()
+	shuffle := false
+	if p, ok := s.player.(interface{ IsShuffle() bool }); ok {
+		shuffle = p.IsShuffle()
+	}
+
+	props := map[string]dbus.Variant{
+		"PlaybackStatus": dbus.MakeVariant(status),
+		"LoopStatus":     dbus.MakeVariant(loopStatus),
+		"Rate":           dbus.MakeVariant(1.0),
+		"Shuffle":        dbus.MakeVariant(shuffle),
+		"Volume":         dbus.MakeVariant(float64(st.Volume) / 100.0),
+		"MinimumRate":    dbus.MakeVariant(1.0),
+		"MaximumRate":    dbus.MakeVariant(1.0),
+		"CanPlay":        dbus.MakeVariant(true),
+		"CanPause":       dbus.MakeVariant(true),
+		"CanSeek":        dbus.MakeVariant(true),
+		"CanGoNext":      dbus.MakeVariant(true),
+		"CanGoPrevious":  dbus.MakeVariant(true),
+		"CanControl":     dbus.MakeVariant(true),
+		"Position":       dbus.MakeVariant(int64(st.Position) / 1000),
+	}
+
+	if st.Track != nil {
+		t := st.Track
+		meta := map[string]dbus.Variant{
+			"mpris:trackid": dbus.MakeVariant(dbus.ObjectPath("/org/mpris/MediaPlayer2/TrackList/NoTrack")),
+			"xesam:title":   dbus.MakeVariant(t.Title),
+			"xesam:artist":  dbus.MakeVariant([]string{t.Artist}),
+			"mpris:artUrl":  dbus.MakeVariant(artURL(t)),
+		}
+		if t.Duration > 0 {
+			meta["mpris:length"] = dbus.MakeVariant(uint64(t.Duration) / 1000)
+		}
+		props["Metadata"] = dbus.MakeVariant(meta)
+	}
+
+	return props, nil
+}
+
+func (s *Server) getHandler(iface, prop string) (dbus.Variant, *dbus.Error) {
+	switch prop {
+	case "PlaybackStatus":
+		status, _ := s.GetPlaybackStatus()
+		return dbus.MakeVariant(status), nil
+	case "LoopStatus":
+		loop, _ := s.GetLoopStatus()
+		return dbus.MakeVariant(loop), nil
+	case "Shuffle":
+		shuffle, _ := s.GetShuffle()
+		return dbus.MakeVariant(shuffle), nil
+	case "Volume":
+		return dbus.MakeVariant(float64(s.player.Status().Volume) / 100.0), nil
+	case "Metadata":
+		meta, _ := s.GetMetadata()
+		return dbus.MakeVariant(meta), nil
+	case "Position":
+		pos, _ := s.GetPosition()
+		return dbus.MakeVariant(pos), nil
+	case "CanSeek":
+		return dbus.MakeVariant(true), nil
+	default:
+		return dbus.MakeVariant(""), nil
+	}
+}
+
+func (s *Server) setHandler(iface, prop string, val dbus.Variant) *dbus.Error {
+	v := val.Value()
+	switch prop {
+	case "Volume":
+		if f, ok := v.(float64); ok {
+			s.player.SetVolume(int(f * 100))
+		}
+	case "LoopStatus":
+		if str, ok := v.(string); ok {
+			s.SetLoopStatus(str)
+		}
+	case "Shuffle":
+		if b, ok := v.(bool); ok {
+			s.SetShuffle(b)
+		}
+	}
+	return nil
+}
+
+// --- Signal emitter ---
+
+func (s *Server) emitPropertyChanged(props map[string]dbus.Variant) {
+	s.conn.Emit(dbusPath,
+		"org.freedesktop.DBus.Properties.PropertiesChanged",
+		ifacePlayer,
+		props,
+		[]string{},
+	)
+}
+
+// --- Polling loop ---
+
+func (s *Server) watchPlayback(ctx context.Context) {
+	defer close(s.quitDone)
+
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	prevStatus := "Stopped"
+	prevTrackID := ""
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			st := s.player.Status()
+
+			var status string
+			switch st.State {
+			case model.Playing:
+				status = "Playing"
+			case model.Paused:
+				status = "Paused"
+			default:
+				status = "Stopped"
+			}
+
+			trackID := ""
+			if st.Track != nil {
+				trackID = st.Track.Title
+			}
+
+			changed := map[string]dbus.Variant{}
+
+			if status != prevStatus {
+				changed["PlaybackStatus"] = dbus.MakeVariant(status)
+				prevStatus = status
+			}
+
+			if trackID != prevTrackID && st.Track != nil {
+				prevTrackID = trackID
+				t := st.Track
+				meta := map[string]dbus.Variant{
+					"mpris:trackid": dbus.MakeVariant(dbus.ObjectPath("/org/mpris/MediaPlayer2/TrackList/NoTrack")),
+					"xesam:title":   dbus.MakeVariant(t.Title),
+					"xesam:artist":  dbus.MakeVariant([]string{t.Artist}),
+					"mpris:artUrl":  dbus.MakeVariant(artURL(t)),
+				}
+				if t.Duration > 0 {
+					meta["mpris:length"] = dbus.MakeVariant(uint64(t.Duration) / 1000)
+				}
+				changed["Metadata"] = dbus.MakeVariant(meta)
+			}
+
+			if len(changed) > 0 {
+				s.emitPropertyChanged(changed)
+			}
+		}
+	}
+}

--- a/internal/mpris/mpris.go
+++ b/internal/mpris/mpris.go
@@ -42,9 +42,14 @@ func New(player model.PlayerInterface) (*Server, error) {
 		return nil, err
 	}
 
-	if _, err := conn.RequestName(dbusName, dbus.NameFlagDoNotQueue); err != nil {
+	reply, err := conn.RequestName(dbusName, dbus.NameFlagDoNotQueue)
+	if err != nil {
 		conn.Close()
 		return nil, err
+	}
+	if reply != dbus.RequestNameReplyPrimaryOwner {
+		conn.Close()
+		return nil, fmt.Errorf("mpris name unavailable: %s", reply)
 	}
 
 	go s.watchPlayback(ctx)
@@ -83,7 +88,6 @@ func (s *Server) Close() {
 func (s *Server) Raise() *dbus.Error { return nil }
 
 func (s *Server) Quit() *dbus.Error {
-	close(s.quitDone)
 	s.quit()
 	return nil
 }
@@ -107,7 +111,9 @@ func (s *Server) Previous() *dbus.Error {
 }
 
 func (s *Server) Pause() *dbus.Error {
-	s.player.Pause()
+	if s.player.Status().State == model.Playing {
+		s.player.Pause()
+	}
 	return nil
 }
 
@@ -405,7 +411,7 @@ func (s *Server) watchPlayback(ctx context.Context) {
 
 			trackID := ""
 			if st.Track != nil {
-				trackID = st.Track.Title
+				trackID = st.Track.ID
 			}
 
 			changed := map[string]dbus.Variant{}

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"strconv"
 	"sync"
 	"time"
 
@@ -19,25 +18,31 @@ import (
 
 // Player controls mpv via JSON IPC over a Unix socket.
 type Player struct {
-	mu        sync.Mutex
-	cmd       *exec.Cmd
-	conn      net.Conn
-	socket    string
-	state     model.PlayerState
-	track     *model.Track
-	pos       time.Duration
-	dur       time.Duration
-	volume    int
-	wasPlay   bool // was playing before current status poll (for end detection)
-	errMsg    string
-	resolving bool   // true while resolving audio URL
-	gen       uint64 // generation counter — incremented on each Play/PlayPaused call
-	resuming  bool   // true during PlayPaused resume — prevents Status() from overriding pause state
-	// Debounce: when Play() is called rapidly (e.g. spamming n/N),
-	// we delay the yt-dlp resolve so only the last skip actually hits YouTube.
+	mu            sync.Mutex
+	cmd           *exec.Cmd
+	conn          net.Conn
+	socket        string
+	state         model.PlayerState
+	track         *model.Track
+	pos           time.Duration
+	dur           time.Duration
+	volume        int
+	wasPlay       bool // was playing before current status poll (for end detection)
+	errMsg        string
+	resolving     bool // true while resolving audio URL
+	gen           uint64
+	resuming      bool // true during PlayPaused resume — prevents Status() from overriding pause state
+	shuffle       bool // shuffle mode enabled
+	loopTrack     bool // loop current track enabled
+	loopPlaylist  bool // loop entire playlist enabled
 	debounceTimer *time.Timer
-	// resolveCancel cancels any in-flight yt-dlp URL resolution, killing the process.
 	resolveCancel context.CancelFunc
+
+	// MPRIS action channels — allow external control (e.g., from DBus)
+	onNext   chan struct{}
+	onPrev   chan struct{}
+	onSeek   chan int64 // position delta in microseconds
+	onSetPos chan int64 // absolute position in microseconds
 }
 
 // ipcResponse is the JSON structure from mpv IPC.
@@ -51,8 +56,12 @@ type ipcResponse struct {
 // New creates a player backed by an mpv subprocess.
 func New() *Player {
 	p := &Player{
-		state:  model.Stopped,
-		volume: 50,
+		state:    model.Stopped,
+		volume:   50,
+		onNext:   make(chan struct{}, 1),
+		onPrev:   make(chan struct{}, 1),
+		onSeek:   make(chan int64, 1),
+		onSetPos: make(chan int64, 1),
 	}
 
 	if _, err := exec.LookPath("mpv"); err != nil {
@@ -152,6 +161,15 @@ func (p *Player) Play(t *model.Track) {
 	p.mu.Lock()
 	p.gen++ // invalidate any in-flight goroutines from previous Play calls
 	myGen := p.gen
+
+	// If same track is already loaded, just unpause (don't restart)
+	if p.conn != nil && p.track != nil && p.track.ID == t.ID {
+		p.state = model.Playing
+		p.sendCommand("set_property", "pause", false)
+		p.mu.Unlock()
+		return
+	}
+
 	p.track = t
 	p.pos = 0
 	p.dur = t.Duration
@@ -185,7 +203,7 @@ func (p *Player) Play(t *model.Track) {
 // Called after the debounce timer fires. The context allows cancellation
 // when the user skips to another track before resolution completes.
 func (p *Player) resolveAndLoad(ctx context.Context, t *model.Track, myGen uint64) {
-	url, err := youtube.ResolveURLCtx(ctx, t.ID)
+	url, thumb, err := youtube.ResolveURLCtx(ctx, t.ID)
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -208,6 +226,10 @@ func (p *Player) resolveAndLoad(ctx context.Context, t *model.Track, myGen uint6
 		return
 	}
 
+	if thumb != "" {
+		t.ThumbnailURL = thumb
+	}
+
 	if p.conn == nil {
 		return
 	}
@@ -220,7 +242,7 @@ func (p *Player) resolveAndLoad(ctx context.Context, t *model.Track, myGen uint6
 	if loadErr != nil {
 		// Maybe expired cached URL — retry once
 		youtube.InvalidateURL(t.ID)
-		url2, err2 := youtube.ResolveURLCtx(ctx, t.ID)
+		url2, _, err2 := youtube.ResolveURLCtx(ctx, t.ID)
 		if err2 != nil {
 			if ctx.Err() != nil {
 				return
@@ -263,7 +285,7 @@ func (p *Player) PlayPaused(t *model.Track, seekPos float64) {
 	p.mu.Unlock()
 
 	go func() {
-		url, err := youtube.ResolveURLCtx(ctx, t.ID)
+		url, thumb, err := youtube.ResolveURLCtx(ctx, t.ID)
 
 		p.mu.Lock()
 		if p.gen != myGen {
@@ -284,6 +306,10 @@ func (p *Player) PlayPaused(t *model.Track, seekPos float64) {
 			return
 		}
 
+		if thumb != "" {
+			t.ThumbnailURL = thumb
+		}
+
 		if p.conn == nil {
 			p.mu.Unlock()
 			return
@@ -297,7 +323,7 @@ func (p *Player) PlayPaused(t *model.Track, seekPos float64) {
 		_, loadErr := p.sendCommand("loadfile", url)
 		if loadErr != nil {
 			youtube.InvalidateURL(t.ID)
-			url2, err2 := youtube.ResolveURLCtx(ctx, t.ID)
+			url2, _, err2 := youtube.ResolveURLCtx(ctx, t.ID)
 			if err2 != nil {
 				if ctx.Err() != nil {
 					p.mu.Unlock()
@@ -370,7 +396,7 @@ func (p *Player) Stop() {
 }
 
 // Seek adjusts position by delta seconds.
-func (p *Player) Seek(deltaSec int) {
+func (p *Player) Seek(deltaSec float64) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -378,7 +404,7 @@ func (p *Player) Seek(deltaSec int) {
 		return
 	}
 
-	p.sendCommand("seek", strconv.Itoa(deltaSec), "relative")
+	p.sendCommand("seek", fmt.Sprintf("%.6f", deltaSec), "relative")
 }
 
 // SeekAbsolute seeks to an absolute position in seconds.
@@ -488,6 +514,60 @@ func (p *Player) SetVolume(v int) {
 		p.sendCommand("set_property", "volume", v)
 	}
 }
+
+// SetShuffle enables or disables shuffle mode.
+func (p *Player) SetShuffle(on bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.shuffle = on
+}
+
+// IsShuffle returns whether shuffle mode is enabled.
+func (p *Player) IsShuffle() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.shuffle
+}
+
+// SetLoopTrack enables or disables track looping.
+func (p *Player) SetLoopTrack(on bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.loopTrack = on
+}
+
+// IsLoopTrack returns whether track looping is enabled.
+func (p *Player) IsLoopTrack() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.loopTrack
+}
+
+// SetLoopPlaylist enables or disables playlist looping.
+func (p *Player) SetLoopPlaylist(on bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.loopPlaylist = on
+}
+
+// IsLoopPlaylist returns whether playlist looping is enabled.
+func (p *Player) IsLoopPlaylist() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.loopPlaylist
+}
+
+// OnNext returns the Next action channel.
+func (p *Player) OnNext() chan struct{} { return p.onNext }
+
+// OnPrev returns the Previous action channel.
+func (p *Player) OnPrev() chan struct{} { return p.onPrev }
+
+// OnSeek returns the Seek action channel.
+func (p *Player) OnSeek() chan int64 { return p.onSeek }
+
+// OnSetPosition returns the SetPosition action channel (absolute microseconds).
+func (p *Player) OnSetPosition() chan int64 { return p.onSetPos }
 
 // ErrMsg returns any error message from initialization.
 func (p *Player) ErrMsg() string {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -17,10 +17,6 @@ import (
 	"github.com/Sadoaz/vimyt/internal/youtube"
 )
 
-// playerGlobal is the shared player instance used by MPRIS goroutines.
-// Set in New() before the program starts.
-var playerGlobal *player.Player
-
 type panel int
 
 const (
@@ -353,9 +349,6 @@ func New(plStore *model.PlaylistStore, p *player.Player) App {
 	qm.cursor = min(qm.cursor, qdata.Len()-1)
 	qm.cursor = max(qm.cursor, 0)
 
-	// Set the global player reference for MPRIS channel polling before creating app
-	playerGlobal = p
-
 	app := App{
 		search:               sm,
 		queue:                qm,
@@ -405,6 +398,9 @@ func New(plStore *model.PlaylistStore, p *player.Player) App {
 	if sess.Volume > 0 {
 		app.player.SetVolume(sess.Volume)
 	}
+	app.player.SetShuffle(app.shuffle)
+	app.player.SetLoopTrack(app.loopTrack)
+	app.player.SetLoopPlaylist(app.loopPlaylist)
 	// Restore radio history cursor
 	app.radioHistCur = sess.RadioHistCur
 	rhVisible, _ := app.radioHistVisible()
@@ -427,13 +423,23 @@ func New(plStore *model.PlaylistStore, p *player.Player) App {
 	return app
 }
 
-// mprisMsg is sent when MPRIS clients trigger next/prev/seek/setpos.
+type mprisAction int
+
+const (
+	mprisNext mprisAction = iota
+	mprisPrev
+	mprisStop
+	mprisSeek
+	mprisSetPosition
+)
+
 type mprisMsg struct {
-	Action string // "next", "prev", "stop", "seek:<delta_μs>", "setpos:<pos_μs>"
+	Action mprisAction
+	Value  int64
 }
 
 func (a App) Init() tea.Cmd {
-	cmds := []tea.Cmd{playerTick(), mprisTick()}
+	cmds := []tea.Cmd{playerTick(), mprisTick(a.player)}
 
 	// Resume playback from last session — load paused and seek (no audio heard)
 	if a.qdata.Current >= 0 && a.qdata.Current < a.qdata.Len() && a.resumePos > 0 {
@@ -446,24 +452,22 @@ func (a App) Init() tea.Cmd {
 // mprisTick runs in a background goroutine, polling MPRIS action channels
 // every 100ms. When a message arrives, it returns it to the Bubble Tea event
 // loop. The Update handler then schedules a new mprisTick goroutine.
-func mprisTick() tea.Cmd {
+func mprisTick(p *player.Player) tea.Cmd {
 	return func() tea.Msg {
-		p := playerGlobal
 		for {
 			if p == nil {
 				time.Sleep(100 * time.Millisecond)
-				p = playerGlobal
 				continue
 			}
 			select {
 			case <-p.OnNext():
-				return mprisMsg{Action: "next"}
+				return mprisMsg{Action: mprisNext}
 			case <-p.OnPrev():
-				return mprisMsg{Action: "prev"}
+				return mprisMsg{Action: mprisPrev}
 			case delta := <-p.OnSeek():
-				return mprisMsg{Action: fmt.Sprintf("seek:%d", delta)}
+				return mprisMsg{Action: mprisSeek, Value: delta}
 			case pos := <-p.OnSetPosition():
-				return mprisMsg{Action: fmt.Sprintf("setpos:%d", pos)}
+				return mprisMsg{Action: mprisSetPosition, Value: pos}
 			case <-time.After(100 * time.Millisecond):
 			}
 		}
@@ -523,25 +527,18 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case mprisMsg:
 		switch msg.Action {
-		case "next":
+		case mprisNext:
 			a.handleMPRISNext()
-		case "prev":
+		case mprisPrev:
 			a.handleMPRISPrev()
-		case "stop":
+		case mprisStop:
 			a.player.Stop()
-		default:
-			if len(msg.Action) > 5 && msg.Action[:5] == "seek:" {
-				var delta int64
-				fmt.Sscanf(msg.Action[5:], "%d", &delta)
-				a.handleMPRISSeek(delta)
-			} else if len(msg.Action) > 7 && msg.Action[:7] == "setpos:" {
-				var pos int64
-				fmt.Sscanf(msg.Action[7:], "%d", &pos)
-				sec := float64(pos) / 1e6
-				a.player.SeekAbsolute(sec)
-			}
+		case mprisSeek:
+			a.handleMPRISSeek(msg.Value)
+		case mprisSetPosition:
+			a.player.SeekAbsolute(float64(msg.Value) / 1e6)
 		}
-		return a, mprisTick()
+		return a, mprisTick(a.player)
 
 	case playerTickMsg:
 		a.tickCount++
@@ -555,9 +552,12 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// The player detects EOF internally and transitions to Stopped.
 		status := a.player.Status()
 
-		// Sync settings controlled via MPRIS (shuffle, loop)
-		a.shuffle = a.player.IsShuffle()
-		a.loopPlaylist = a.player.IsLoopPlaylist()
+		if a.player.IsShuffle() != a.shuffle {
+			a.shuffle = a.player.IsShuffle()
+		}
+		if a.player.IsLoopPlaylist() != a.loopPlaylist {
+			a.loopPlaylist = a.player.IsLoopPlaylist()
+		}
 		if a.player.IsLoopTrack() != a.loopTrack {
 			a.loopTrack = a.player.IsLoopTrack()
 			a.loopTotal = 0

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -17,6 +17,10 @@ import (
 	"github.com/Sadoaz/vimyt/internal/youtube"
 )
 
+// playerGlobal is the shared player instance used by MPRIS goroutines.
+// Set in New() before the program starts.
+var playerGlobal *player.Player
+
 type panel int
 
 const (
@@ -105,6 +109,7 @@ type App struct {
 	autoplay            bool            // auto-advance to next track on EOF
 	shuffle             bool            // randomize next track selection
 	loopTrack           bool            // loop current track on EOF
+	loopPlaylist        bool            // loop entire playlist on EOF
 	loopCount           int             // remaining loops (0 = infinite)
 	loopTotal           int             // original loop count for display
 	pinSearch           bool            // keep search panel expanded when unfocused
@@ -232,7 +237,7 @@ func checkDeps() string {
 }
 
 // New creates a new App model, restoring previous session state.
-func New(plStore *model.PlaylistStore) App {
+func New(plStore *model.PlaylistStore, p *player.Player) App {
 	ci := textinput.New()
 	ci.Prompt = ":"
 	ci.CharLimit = 10
@@ -348,6 +353,9 @@ func New(plStore *model.PlaylistStore) App {
 	qm.cursor = min(qm.cursor, qdata.Len()-1)
 	qm.cursor = max(qm.cursor, 0)
 
+	// Set the global player reference for MPRIS channel polling before creating app
+	playerGlobal = p
+
 	app := App{
 		search:               sm,
 		queue:                qm,
@@ -355,7 +363,7 @@ func New(plStore *model.PlaylistStore) App {
 		history:              hm,
 		overlay:              newOverlayModel(),
 		qdata:                qdata,
-		player:               player.New(),
+		player:               p,
 		focusedPanel:         v,
 		colonInput:           ci,
 		gotoInput:            gi,
@@ -385,6 +393,7 @@ func New(plStore *model.PlaylistStore) App {
 		showArtistsPanel:     sess.ShowArtists,
 		pinArtists:           sess.PinArtists,
 		loopTrack:            sess.LoopTrack,
+		loopPlaylist:         sess.LoopPlaylist,
 		loopCount:            sess.LoopCount,
 		loopTotal:            sess.LoopTotal,
 		theme:                ThemeFromMap(sess.Theme),
@@ -418,14 +427,89 @@ func New(plStore *model.PlaylistStore) App {
 	return app
 }
 
+// mprisMsg is sent when MPRIS clients trigger next/prev/seek/setpos.
+type mprisMsg struct {
+	Action string // "next", "prev", "stop", "seek:<delta_μs>", "setpos:<pos_μs>"
+}
+
 func (a App) Init() tea.Cmd {
-	cmds := []tea.Cmd{playerTick()}
+	cmds := []tea.Cmd{playerTick(), mprisTick()}
+
 	// Resume playback from last session — load paused and seek (no audio heard)
 	if a.qdata.Current >= 0 && a.qdata.Current < a.qdata.Len() && a.resumePos > 0 {
 		t := &a.qdata.Tracks[a.qdata.Current]
 		a.player.PlayPaused(t, a.resumePos)
 	}
 	return tea.Batch(cmds...)
+}
+
+// mprisTick runs in a background goroutine, polling MPRIS action channels
+// every 100ms. When a message arrives, it returns it to the Bubble Tea event
+// loop. The Update handler then schedules a new mprisTick goroutine.
+func mprisTick() tea.Cmd {
+	return func() tea.Msg {
+		p := playerGlobal
+		for {
+			if p == nil {
+				time.Sleep(100 * time.Millisecond)
+				p = playerGlobal
+				continue
+			}
+			select {
+			case <-p.OnNext():
+				return mprisMsg{Action: "next"}
+			case <-p.OnPrev():
+				return mprisMsg{Action: "prev"}
+			case delta := <-p.OnSeek():
+				return mprisMsg{Action: fmt.Sprintf("seek:%d", delta)}
+			case pos := <-p.OnSetPosition():
+				return mprisMsg{Action: fmt.Sprintf("setpos:%d", pos)}
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	}
+}
+
+// handleMPRISNext skips to the next track.
+func (a *App) handleMPRISNext() {
+	if a.qdata.Len() == 0 {
+		return
+	}
+	a.pushPrev()
+	if a.shuffle {
+		idx := a.pickShuffleNext()
+		a.qdata.Current = idx
+		a.playTrack(&a.qdata.Tracks[idx], "queue")
+	} else {
+		t := a.qdata.Next()
+		if t != nil {
+			a.playTrack(t, "queue")
+		} else {
+			a.player.Stop()
+		}
+	}
+}
+
+// handleMPRISPrev plays the previous track in the history stack.
+func (a *App) handleMPRISPrev() {
+	if len(a.prevStack) == 0 {
+		return
+	}
+	idx := a.prevStack[len(a.prevStack)-1]
+	a.prevStack = a.prevStack[:len(a.prevStack)-1]
+	if idx >= 0 && idx < a.qdata.Len() {
+		a.qdata.Current = idx
+		a.player.Play(&a.qdata.Tracks[idx])
+		if a.playHistory != nil {
+			a.playHistory.Add(a.qdata.Tracks[idx], "queue")
+		}
+	}
+}
+
+// handleMPRISSeek seeks by delta microseconds.
+func (a *App) handleMPRISSeek(delta int64) {
+	sec := float64(delta) / 1e6
+	a.player.Seek(sec)
 }
 
 func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -436,6 +520,28 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.statusMsg = ""
 		}
 		return a, nil
+
+	case mprisMsg:
+		switch msg.Action {
+		case "next":
+			a.handleMPRISNext()
+		case "prev":
+			a.handleMPRISPrev()
+		case "stop":
+			a.player.Stop()
+		default:
+			if len(msg.Action) > 5 && msg.Action[:5] == "seek:" {
+				var delta int64
+				fmt.Sscanf(msg.Action[5:], "%d", &delta)
+				a.handleMPRISSeek(delta)
+			} else if len(msg.Action) > 7 && msg.Action[:7] == "setpos:" {
+				var pos int64
+				fmt.Sscanf(msg.Action[7:], "%d", &pos)
+				sec := float64(pos) / 1e6
+				a.player.SeekAbsolute(sec)
+			}
+		}
+		return a, mprisTick()
 
 	case playerTickMsg:
 		a.tickCount++
@@ -448,6 +554,15 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Poll mpv status — Status() queries mpv IPC for real position/state.
 		// The player detects EOF internally and transitions to Stopped.
 		status := a.player.Status()
+
+		// Sync settings controlled via MPRIS (shuffle, loop)
+		a.shuffle = a.player.IsShuffle()
+		a.loopPlaylist = a.player.IsLoopPlaylist()
+		if a.player.IsLoopTrack() != a.loopTrack {
+			a.loopTrack = a.player.IsLoopTrack()
+			a.loopTotal = 0
+			a.loopCount = 0
+		}
 
 		// Auto-advance: if player stopped (track ended).
 		// Loop track takes priority: replay the same track.
@@ -469,7 +584,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					a.loopCount = a.loopTotal
 					shouldAdvance = true
 				}
-			} else if a.autoplay {
+			} else if a.loopPlaylist || a.autoplay {
 				shouldAdvance = true
 			}
 			if shouldAdvance && a.qdata.Len() > 0 {
@@ -506,7 +621,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				a.prefetchNextIdx = nextIdx
 				ctx, cancel := context.WithCancel(context.Background())
 				a.prefetchCancel = cancel
-				go youtube.ResolveURLCtx(ctx, nextTrack.ID)
+				go func() { youtube.ResolveURLCtx(ctx, nextTrack.ID) }()
 			}
 		}
 		return a, playerTick()

--- a/internal/tui/nowplaying.go
+++ b/internal/tui/nowplaying.go
@@ -27,7 +27,7 @@ var (
 
 var npSettingStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
 
-func renderNowPlaying(status model.PlayerStatus, width int, favSet map[string]bool, autoplay bool, shuffle bool, loopTrack bool, loopTotal int, tick int) string {
+func renderNowPlaying(status model.PlayerStatus, width int, favSet map[string]bool, autoplay bool, shuffle bool, loopTrack bool, loopPlaylist bool, loopTotal int, tick int) string {
 	if status.Track == nil {
 		line := "  Nothing playing"
 		return nowPlayingStyle.Width(width).MaxWidth(width).Render(line)
@@ -54,6 +54,9 @@ func renderNowPlaying(status model.PlayerStatus, width int, favSet map[string]bo
 		} else {
 			stateStr += npSettingStyle.Render(fmt.Sprintf(" [L%d]", loopTotal))
 		}
+	}
+	if loopPlaylist {
+		stateStr += npSettingStyle.Render(" [LP]")
 	}
 
 	pos := formatDuration(status.Position)
@@ -101,7 +104,7 @@ func renderNowPlaying(status model.PlayerStatus, width int, favSet map[string]bo
 }
 
 // renderInputWithNowPlaying shows a text input on the left and abbreviated now-playing on the right.
-func renderInputWithNowPlaying(inputView string, status model.PlayerStatus, width int, autoplay bool, shuffle bool, loopTrack bool, loopTotal int) string {
+func renderInputWithNowPlaying(inputView string, status model.PlayerStatus, width int, autoplay bool, shuffle bool, loopTrack bool, loopPlaylist bool, loopTotal int) string {
 	if status.Track == nil {
 		// No track — just show the input full-width
 		return nowPlayingStyle.Width(width).MaxWidth(width).Render(inputView)
@@ -126,6 +129,9 @@ func renderInputWithNowPlaying(inputView string, status model.PlayerStatus, widt
 		} else {
 			stateIcons += npSettingStyle.Render(fmt.Sprintf(" [L%d]", loopTotal))
 		}
+	}
+	if loopPlaylist {
+		stateIcons += npSettingStyle.Render(" [LP]")
 	}
 
 	inputW := lipgloss.Width(inputView)

--- a/internal/tui/playback.go
+++ b/internal/tui/playback.go
@@ -221,6 +221,7 @@ func (a *App) saveSession() {
 		PinArtists:     a.pinArtists,
 		ArtistsCur:     a.artistsPanelCur,
 		LoopTrack:      a.loopTrack,
+		LoopPlaylist:   a.loopPlaylist,
 		LoopCount:      a.loopCount,
 		LoopTotal:      a.loopTotal,
 		Theme:          a.theme.ToMap(),

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -127,9 +127,9 @@ func (a App) View() string {
 	// Bottom bar
 	var bottomBar string
 	if a.gotoActive {
-		bottomBar = renderInputWithNowPlaying(a.gotoInput.View(), a.player.Status(), a.width, a.autoplay, a.shuffle, a.loopTrack, a.loopTotal)
+		bottomBar = renderInputWithNowPlaying(a.gotoInput.View(), a.player.Status(), a.width, a.autoplay, a.shuffle, a.loopTrack, a.loopPlaylist, a.loopTotal)
 	} else if a.colonActive {
-		bottomBar = renderInputWithNowPlaying(a.colonInput.View(), a.player.Status(), a.width, a.autoplay, a.shuffle, a.loopTrack, a.loopTotal)
+		bottomBar = renderInputWithNowPlaying(a.colonInput.View(), a.player.Status(), a.width, a.autoplay, a.shuffle, a.loopTrack, a.loopPlaylist, a.loopTotal)
 	} else if a.playlist.isFilterActive() {
 		bottomBar = "/" + a.playlist.input.View()
 	} else if a.queue.isFilterActive() {
@@ -147,7 +147,7 @@ func (a App) View() string {
 	} else if a.statusMsg != "" {
 		bottomBar = sbBgStyle.Width(a.width).Render("  " + a.statusMsg)
 	} else {
-		bottomBar = renderNowPlaying(a.player.Status(), a.width, favSet, a.autoplay, a.shuffle, a.loopTrack, a.loopTotal, a.tickCount)
+		bottomBar = renderNowPlaying(a.player.Status(), a.width, favSet, a.autoplay, a.shuffle, a.loopTrack, a.loopPlaylist, a.loopTotal, a.tickCount)
 	}
 
 	// Content area height = total height minus bottom bar (1)

--- a/internal/tui/settings.go
+++ b/internal/tui/settings.go
@@ -21,18 +21,19 @@ var settingsOptions = []struct {
 	{"Autoplay", "Auto-advance to next track when current ends"},        // 0
 	{"Shuffle", "Randomize next track selection"},                       // 1
 	{"Loop Track", "Replay current track (∞ or x times)"},               // 2
-	{"Focus Queue", "Auto-focus queue panel when playing a track"},      // 3
-	{"Rel Numbers", "Show relative line numbers (vim-style)"},           // 4
-	{"Pin Search", "Keep search panel expanded when unfocused"},         // 5
-	{"Pin Playlist", "Keep playlist detail expanded when unfocused"},    // 6
-	{"Pin Radio", "Keep radio history expanded when unfocused"},         // 7
-	{"Pin Artists", "Keep artists panel expanded when unfocused"},       // 8
-	{"Show History", "Show play history panel below playlists"},         // 9
-	{"Show Radio", "Show radio history panel below play history"},       // 10
-	{"Show Artists", "Show artists panel"},                              // 11
-	{"Colors", "Customize TUI colors"},                                  // 12
-	{"YT Auth", "Use browser cookies to access your private playlists"}, // 13
-	{"Import", "Import playlist from YouTube URL"},                      // 14
+	{"Loop Playlist", "Loop entire playlist"},                           // 3
+	{"Focus Queue", "Auto-focus queue panel when playing a track"},      // 4
+	{"Rel Numbers", "Show relative line numbers (vim-style)"},           // 5
+	{"Pin Search", "Keep search panel expanded when unfocused"},         // 6
+	{"Pin Playlist", "Keep playlist detail expanded when unfocused"},    // 7
+	{"Pin Radio", "Keep radio history expanded when unfocused"},         // 8
+	{"Pin Artists", "Keep artists panel expanded when unfocused"},       // 9
+	{"Show History", "Show play history panel below playlists"},         // 10
+	{"Show Radio", "Show radio history panel below play history"},       // 11
+	{"Show Artists", "Show artists panel"},                              // 12
+	{"Colors", "Customize TUI colors"},                                  // 13
+	{"YT Auth", "Use browser cookies to access your private playlists"}, // 14
+	{"Import", "Import playlist from YouTube URL"},                      // 15
 }
 
 // browserOptions is the cycle for the Auth Browser setting.
@@ -47,26 +48,28 @@ func (a *App) settingValue(idx int) bool {
 	case 2:
 		return a.loopTrack
 	case 3:
-		return a.autoFocusQueue
+		return a.loopPlaylist
 	case 4:
-		return a.relNumbers
+		return a.autoFocusQueue
 	case 5:
-		return a.pinSearch
+		return a.relNumbers
 	case 6:
-		return a.pinPlaylist
+		return a.pinSearch
 	case 7:
-		return a.pinRadio
+		return a.pinPlaylist
 	case 8:
-		return a.pinArtists
+		return a.pinRadio
 	case 9:
-		return a.showHistory
+		return a.pinArtists
 	case 10:
-		return a.showRadio
+		return a.showHistory
 	case 11:
-		return a.showArtistsPanel
+		return a.showRadio
 	case 12:
-		return false // Colors — not a boolean toggle
+		return a.showArtistsPanel
 	case 13:
+		return false // Colors — not a boolean toggle
+	case 14:
 		return a.cookieBrowser != ""
 	}
 	return false
@@ -81,12 +84,15 @@ func (a *App) toggleSetting(idx int) {
 		if !a.shuffle {
 			a.shufflePlayed = nil
 		}
+		a.player.SetShuffle(a.shuffle)
 	case 2:
 		// Loop Track: cycle Off → ∞ → input mode
 		if !a.loopTrack {
 			a.loopTrack = true
 			a.loopCount = 0
 			a.loopTotal = 0
+			a.loopPlaylist = false
+			a.player.SetLoopPlaylist(false)
 		} else if a.loopTotal == 0 {
 			a.settingsLoopInput = true
 			a.settingsLoopInp.SetValue("")
@@ -96,44 +102,55 @@ func (a *App) toggleSetting(idx int) {
 			a.loopCount = 0
 			a.loopTotal = 0
 		}
+		a.player.SetLoopTrack(a.loopTrack)
 	case 3:
-		a.autoFocusQueue = !a.autoFocusQueue
+		a.loopPlaylist = !a.loopPlaylist
+		a.player.SetLoopPlaylist(a.loopPlaylist)
+		if a.loopPlaylist {
+			a.loopTrack = false
+			a.player.SetLoopTrack(false)
+		}
 	case 4:
-		a.relNumbers = !a.relNumbers
+		a.autoFocusQueue = !a.autoFocusQueue
 	case 5:
-		a.pinSearch = !a.pinSearch
+		a.relNumbers = !a.relNumbers
 	case 6:
-		a.pinPlaylist = !a.pinPlaylist
+		a.pinSearch = !a.pinSearch
 	case 7:
-		a.pinRadio = !a.pinRadio
+		a.pinPlaylist = !a.pinPlaylist
 	case 8:
-		a.pinArtists = !a.pinArtists
+		a.pinRadio = !a.pinRadio
 	case 9:
+		a.pinArtists = !a.pinArtists
+	case 10:
 		a.showHistory = !a.showHistory
 		if !a.showHistory && a.focusedPanel == panelHistory {
 			a.focusedPanel = panelPlaylist
 		}
-	case 10:
+	case 11:
 		a.showRadio = !a.showRadio
 		if !a.showRadio && a.focusedPanel == panelRadioHist {
 			a.focusedPanel = panelPlaylist
 		}
-	case 11:
+	case 12:
 		a.showArtistsPanel = !a.showArtistsPanel
 		if !a.showArtistsPanel && a.focusedPanel == panelArtists {
 			a.focusedPanel = panelPlaylist
 		}
-	case 12:
-		// Colors — opens color editor, handled in updateSettings
 	case 13:
+		// Colors — opens color editor, handled in updateSettings
+	case 14:
 		a.cycleBrowser(1)
 	}
 }
 
 func (a *App) loopOff() {
 	a.loopTrack = false
+	a.loopPlaylist = false
 	a.loopCount = 0
 	a.loopTotal = 0
+	a.player.SetLoopTrack(false)
+	a.player.SetLoopPlaylist(false)
 }
 
 func (a *App) cycleBrowser(dir int) {

--- a/internal/youtube/cache.go
+++ b/internal/youtube/cache.go
@@ -178,7 +178,7 @@ func tryResolve(parent context.Context, id, format string, cookies []string) (ur
 		return "", "", fmt.Errorf("cancelled: %w", err)
 	}
 
-	args := []string{"-f", format, "--print", "url", "--print", "thumbnail", id, "--no-warnings", "--extractor-retries", "3"}
+	args := []string{"-f", format, "--print", "%(url)s\t%(thumbnail)s", "--no-warnings", "--extractor-retries", "3", id}
 	args = append(args, cookies...)
 	ctx, cancel := context.WithTimeout(parent, 30*time.Second)
 	defer cancel()
@@ -193,13 +193,14 @@ func tryResolve(parent context.Context, id, format string, cookies []string) (ur
 		return "", "", fmt.Errorf("yt-dlp resolve failed for %s (format %s): %w (%s)", id, format, err, errMsg)
 	}
 
-	lines := strings.SplitN(strings.TrimSpace(stdout.String()), "\n", 3)
-	if len(lines) == 0 || lines[0] == "" {
+	line := strings.TrimSpace(stdout.String())
+	if line == "" {
 		return "", "", fmt.Errorf("yt-dlp returned empty URL for %s (format %s)", id, format)
 	}
-	url = strings.TrimSpace(lines[0])
-	if len(lines) > 1 {
-		thumbnail = strings.TrimSpace(lines[1])
+	fields := strings.SplitN(line, "\t", 2)
+	url = strings.TrimSpace(fields[0])
+	if len(fields) > 1 {
+		thumbnail = strings.TrimSpace(fields[1])
 	}
 	return url, thumbnail, nil
 }

--- a/internal/youtube/cache.go
+++ b/internal/youtube/cache.go
@@ -49,8 +49,9 @@ const urlTTL = 4 * time.Hour
 const maxURLCacheSize = 200
 
 type urlEntry struct {
-	url      string
-	cachedAt time.Time
+	url       string
+	thumbnail string
+	cachedAt  time.Time
 }
 
 // URLCache caches resolved audio stream URLs by YouTube video ID.
@@ -75,11 +76,25 @@ func (c *URLCache) Get(id string) string {
 	return e.url
 }
 
-// Set stores an audio URL for a video ID with the current timestamp.
-func (c *URLCache) Set(id, url string) {
+// GetThumbnail returns the cached thumbnail URL for a video ID, or empty string if not cached or expired.
+func (c *URLCache) GetThumbnail(id string) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e, ok := c.entries[id]
+	if !ok {
+		return ""
+	}
+	if time.Since(e.cachedAt) > urlTTL {
+		return ""
+	}
+	return e.thumbnail
+}
+
+// Set stores an audio URL and thumbnail URL for a video ID with the current timestamp.
+func (c *URLCache) Set(id, url, thumbnail string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.entries[id] = urlEntry{url: url, cachedAt: time.Now()}
+	c.entries[id] = urlEntry{url: url, thumbnail: thumbnail, cachedAt: time.Now()}
 	// Evict expired entries if cache is getting large
 	if len(c.entries) > maxURLCacheSize {
 		now := time.Now()
@@ -98,25 +113,26 @@ func (c *URLCache) Invalidate(id string) {
 	delete(c.entries, id)
 }
 
-// ResolveURL returns the audio stream URL for a YouTube video ID.
+// ResolveURL returns the audio stream URL and thumbnail URL for a YouTube video ID.
 // Checks cache first, falls back to yt-dlp subprocess.
-func ResolveURL(id string) (string, error) {
+func ResolveURL(id string) (url, thumbnail string, err error) {
 	return ResolveURLCtx(context.Background(), id)
 }
 
 // ResolveURLCtx is like ResolveURL but accepts a context for cancellation.
 // When the context is cancelled, any in-flight yt-dlp process is killed.
-func ResolveURLCtx(ctx context.Context, id string) (string, error) {
-	if url := urlCache.Get(id); url != "" {
-		return url, nil
+// Returns the audio stream URL and the thumbnail URL.
+func ResolveURLCtx(ctx context.Context, id string) (url, thumbnail string, err error) {
+	if u := urlCache.Get(id); u != "" {
+		return u, urlCache.GetThumbnail(id), nil
 	}
 
-	url, err := fetchAudioURL(ctx, id)
+	url, thumbnail, err = fetchAudioURL(ctx, id)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	urlCache.Set(id, url)
-	return url, nil
+	urlCache.Set(id, url, thumbnail)
+	return url, thumbnail, nil
 }
 
 // InvalidateURL removes a cached URL so next ResolveURL re-fetches.
@@ -124,7 +140,7 @@ func InvalidateURL(id string) {
 	urlCache.Invalidate(id)
 }
 
-func fetchAudioURL(parent context.Context, id string) (string, error) {
+func fetchAudioURL(parent context.Context, id string) (url, thumbnail string, err error) {
 	// Try formats in order: bestaudio, bestaudio*, best (fallback for videos without separate audio).
 	// Format availability doesn't depend on cookies, so we try all formats with the
 	// current cookie config first. Only if every format fails AND cookies are enabled
@@ -135,33 +151,34 @@ func fetchAudioURL(parent context.Context, id string) (string, error) {
 
 	var lastErr error
 	for _, f := range formats {
-		if url, err := tryResolve(parent, id, f, cookies); err == nil {
-			return url, nil
+		if u, t, e := tryResolve(parent, id, f, cookies); e == nil {
+			return u, t, nil
 		} else {
-			lastErr = err
+			lastErr = e
 		}
 	}
 
 	// If cookies were enabled and all formats failed, retry primary format
 	// without cookies in case the cookie auth itself is the problem.
 	if len(cookies) > 0 {
-		if url, err := tryResolve(parent, id, "bestaudio", nil); err == nil {
-			return url, nil
+		if u, t, e := tryResolve(parent, id, "bestaudio", nil); e == nil {
+			return u, t, nil
 		} else {
-			lastErr = err
+			lastErr = e
 		}
 	}
 
-	return "", lastErr
+	return "", "", lastErr
 }
 
-// tryResolve attempts a single yt-dlp --get-url call for the given format and cookie config.
-func tryResolve(parent context.Context, id, format string, cookies []string) (string, error) {
+// tryResolve attempts a single yt-dlp call for the given format and cookie config.
+// Returns the audio stream URL and an optional thumbnail URL.
+func tryResolve(parent context.Context, id, format string, cookies []string) (url, thumbnail string, err error) {
 	if err := parent.Err(); err != nil {
-		return "", fmt.Errorf("cancelled: %w", err)
+		return "", "", fmt.Errorf("cancelled: %w", err)
 	}
 
-	args := []string{"-f", format, "--get-url", id, "--no-warnings", "--extractor-retries", "3"}
+	args := []string{"-f", format, "--print", "url", "--print", "thumbnail", id, "--no-warnings", "--extractor-retries", "3"}
 	args = append(args, cookies...)
 	ctx, cancel := context.WithTimeout(parent, 30*time.Second)
 	defer cancel()
@@ -173,12 +190,16 @@ func tryResolve(parent context.Context, id, format string, cookies []string) (st
 
 	if err := cmd.Run(); err != nil {
 		errMsg := strings.TrimSpace(stderr.String())
-		return "", fmt.Errorf("yt-dlp get-url failed for %s (format %s): %w (%s)", id, format, err, errMsg)
+		return "", "", fmt.Errorf("yt-dlp resolve failed for %s (format %s): %w (%s)", id, format, err, errMsg)
 	}
 
-	url := strings.TrimSpace(stdout.String())
-	if url == "" {
-		return "", fmt.Errorf("yt-dlp returned empty URL for %s (format %s)", id, format)
+	lines := strings.SplitN(strings.TrimSpace(stdout.String()), "\n", 3)
+	if len(lines) == 0 || lines[0] == "" {
+		return "", "", fmt.Errorf("yt-dlp returned empty URL for %s (format %s)", id, format)
 	}
-	return url, nil
+	url = strings.TrimSpace(lines[0])
+	if len(lines) > 1 {
+		thumbnail = strings.TrimSpace(lines[1])
+	}
+	return url, thumbnail, nil
 }

--- a/internal/youtube/search.go
+++ b/internal/youtube/search.go
@@ -28,10 +28,11 @@ var (
 
 // ytdlpResult is the JSON structure from yt-dlp --flat-playlist --dump-json.
 type ytdlpResult struct {
-	ID       string  `json:"id"`
-	Title    string  `json:"title"`
-	Channel  string  `json:"channel"`
-	Duration float64 `json:"duration"`
+	ID        string  `json:"id"`
+	Title     string  `json:"title"`
+	Channel   string  `json:"channel"`
+	Duration  float64 `json:"duration"`
+	Thumbnail string  `json:"thumbnail"`
 }
 
 // Search queries YouTube via yt-dlp and returns up to 20 results.
@@ -90,10 +91,11 @@ func Search(query string) ([]model.Track, error) {
 		dur := time.Duration(r.Duration * float64(time.Second))
 
 		tracks = append(tracks, model.Track{
-			ID:       r.ID,
-			Title:    title,
-			Artist:   artist,
-			Duration: dur,
+			ID:           r.ID,
+			Title:        title,
+			Artist:       artist,
+			Duration:     dur,
+			ThumbnailURL: r.Thumbnail,
 		})
 	}
 
@@ -264,10 +266,11 @@ func fetchRadioPlaylist(videoID string) []model.Track {
 		dur := time.Duration(r.Duration * float64(time.Second))
 
 		pool = append(pool, model.Track{
-			ID:       r.ID,
-			Title:    title,
-			Artist:   artist,
-			Duration: dur,
+			ID:           r.ID,
+			Title:        title,
+			Artist:       artist,
+			Duration:     dur,
+			ThumbnailURL: r.Thumbnail,
 		})
 	}
 
@@ -277,11 +280,12 @@ func fetchRadioPlaylist(videoID string) []model.Track {
 
 // ytdlpPlaylistResult extends ytdlpResult with playlist-level metadata.
 type ytdlpPlaylistResult struct {
-	ID       string  `json:"id"`
-	Title    string  `json:"title"`
-	Channel  string  `json:"channel"`
-	Duration float64 `json:"duration"`
-	Playlist string  `json:"playlist_title"`
+	ID        string  `json:"id"`
+	Title     string  `json:"title"`
+	Channel   string  `json:"channel"`
+	Duration  float64 `json:"duration"`
+	Thumbnail string  `json:"thumbnail"`
+	Playlist  string  `json:"playlist_title"`
 }
 
 const maxImportTracks = 1000
@@ -341,10 +345,11 @@ func FetchPlaylist(url string) (string, []model.Track, error) {
 		dur := time.Duration(r.Duration * float64(time.Second))
 
 		tracks = append(tracks, model.Track{
-			ID:       r.ID,
-			Title:    title,
-			Artist:   artist,
-			Duration: dur,
+			ID:           r.ID,
+			Title:        title,
+			Artist:       artist,
+			Duration:     dur,
+			ThumbnailURL: r.Thumbnail,
 		})
 	}
 

--- a/main.go
+++ b/main.go
@@ -2,24 +2,39 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/Sadoaz/vimyt/internal/model"
+	"github.com/Sadoaz/vimyt/internal/mpris"
+	"github.com/Sadoaz/vimyt/internal/player"
 	"github.com/Sadoaz/vimyt/internal/tui"
 )
 
 func main() {
+	p := player.New()
+	if msg := p.ErrMsg(); msg != "" {
+		log.Printf("player: %s", msg)
+	}
+
+	m, err := mpris.New(p)
+	if err != nil {
+		log.Printf("mpris: %v", err)
+	} else {
+		defer m.Close()
+	}
+
 	plStore, err := model.NewPlaylistStore()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading playlists: %v\n", err)
 		os.Exit(1)
 	}
 
-	app := tui.New(plStore)
-	p := tea.NewProgram(app, tea.WithAltScreen())
-	if _, err := p.Run(); err != nil {
+	app := tui.New(plStore, p)
+	p2 := tea.NewProgram(app, tea.WithAltScreen())
+	if _, err := p2.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error running vimyt: %v\n", err)
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -19,11 +20,13 @@ func main() {
 		log.Printf("player: %s", msg)
 	}
 
-	m, err := mpris.New(p)
-	if err != nil {
-		log.Printf("mpris: %v", err)
-	} else {
-		defer m.Close()
+	if runtime.GOOS == "linux" {
+		m, err := mpris.New(p)
+		if err != nil {
+			log.Printf("mpris: %v", err)
+		} else {
+			defer m.Close()
+		}
 	}
 
 	plStore, err := model.NewPlaylistStore()


### PR DESCRIPTION
## Summary

- Full MPRIS server implementation (org.mpris.MediaPlayer2 and org.mpris.MediaPlayer2.Player) with Next, Previous, Play, Pause, Stop, PlayPause, Seek, SetPosition, LoopStatus, Shuffle, Volume, and album art (mpris:artUrl)
- Player action channels (OnNext, OnPrev, OnSeek, OnSetPosition) bridged into the Bubble Tea event loop via a background polling goroutine
- Loop Playlist setting (mutually exclusive with Loop Track), synced bidirectionally between MPRIS, TUI settings, and Player state
- Album art thumbnails: extracted via yt-dlp --print thumbnail during playback or from --dump-json on search, with fallback to hqdefault.jpg
- Seek(float64) for sub-second precision
- Same-track replay doesn't restart playback (just unpauses)
- Player state structs and session persistence updated for new fields