### PR TITLE
feat: add Discord Rich Presence support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,31 @@ Press `S` to open settings:
 - Show/Hide History / Radio History / Artists
 - YT Auth -- browser cookie auth (Firefox, Chrome, Chromium, Brave, Edge) for private playlists
 - Import Playlist by URL
+- Discord Rich Presence -- show the current track as a "Listening to ..." status
+
+## Discord Rich Presence
+
+vimyt can publish the currently playing track to Discord as a "Listening to ..."
+status, with title, artist, album art, a progress bar, and an optional "Listen
+on YT Music" button. It talks to a running Discord client over its local IPC
+socket, so nothing extra needs to be installed.
+
+Because Discord ties the activity name to an application, you supply your own
+application ID the first time:
+
+1. In settings (`S`), select **Set up Discord RPC**.
+2. Follow the on-screen steps: create an application at
+   [discord.com/developers/applications](https://discord.com/developers/applications),
+   copy its **Application ID**, and enable **Settings > Activity Privacy >
+   Share your detected activities** in Discord.
+3. Paste the Application ID and press Enter.
+
+The application's name is what shows up as "Listening to <name>", so name it
+whatever you want the status to read (e.g. "vimyt"). Once set up, Rich Presence
+and the listen button are enabled by default and can be toggled in settings; the
+setup entry becomes **Change Discord App ID**.
+
+Set `VIMYT_DISCORD_APP_ID` to override the configured ID from the environment.
 
 ## Data Storage
 

--- a/internal/discord/discord.go
+++ b/internal/discord/discord.go
@@ -1,0 +1,378 @@
+// Package discord implements a minimal Discord Rich Presence (IPC) client
+// that publishes the currently playing track as a "Listening to vimyt"
+// activity. It speaks Discord's local IPC protocol directly over the
+// discord-ipc-N unix socket, so it needs no third-party dependency.
+package discord
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/Sadoaz/vimyt/internal/model"
+)
+
+// IPC opcodes.
+const (
+	opHandshake uint32 = 0
+	opFrame     uint32 = 1
+	opClose     uint32 = 2
+)
+
+// activityListening is the Discord activity type for "Listening to …".
+const activityListening = 2
+
+type timestamps struct {
+	Start int64 `json:"start,omitempty"`
+	End   int64 `json:"end,omitempty"`
+}
+
+type assets struct {
+	LargeImage string `json:"large_image,omitempty"`
+	LargeText  string `json:"large_text,omitempty"`
+}
+
+type button struct {
+	Label string `json:"label"`
+	URL   string `json:"url"`
+}
+
+type activity struct {
+	Type       int         `json:"type"`
+	Details    string      `json:"details,omitempty"`
+	State      string      `json:"state,omitempty"`
+	Timestamps *timestamps `json:"timestamps,omitempty"`
+	Assets     *assets     `json:"assets,omitempty"`
+	Buttons    []button    `json:"buttons,omitempty"`
+}
+
+// Server polls the player and pushes Rich Presence updates to Discord.
+type Server struct {
+	player model.PlayerInterface
+	appID  string
+
+	mu         sync.Mutex
+	enabled    bool
+	showButton bool
+
+	conn        net.Conn
+	lastConnTry time.Time
+	lastSig     string
+	lastStart   int64 // unix-ms start used for the current progress bar
+
+	quit     context.CancelFunc
+	quitDone chan struct{}
+}
+
+// New starts a Rich Presence server. It never returns an error: if Discord is
+// not running the server retries in the background and stays inert otherwise.
+//
+// appID is the user-supplied Discord application ID. While it is empty the
+// server stays inert; the TUI sets it via SetAppID once the user has set up
+// their own Discord application. The VIMYT_DISCORD_APP_ID environment variable,
+// if set, overrides whatever the TUI provides.
+func New(player model.PlayerInterface, enabled, showButton bool, appID string) *Server {
+	if env := os.Getenv("VIMYT_DISCORD_APP_ID"); env != "" {
+		appID = env
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Server{
+		player:     player,
+		appID:      appID,
+		enabled:    enabled,
+		showButton: showButton,
+		quit:       cancel,
+		quitDone:   make(chan struct{}),
+	}
+	go s.run(ctx)
+	return s
+}
+
+// SetEnabled toggles whether presence is published. When disabled the current
+// activity is cleared on the next tick.
+func (s *Server) SetEnabled(on bool) {
+	s.mu.Lock()
+	s.enabled = on
+	s.mu.Unlock()
+}
+
+// SetAppID swaps the Discord application ID. It drops any live connection so
+// the next tick re-handshakes with the new ID. Ignored if the environment
+// override is in effect. An empty id leaves the server inert.
+func (s *Server) SetAppID(id string) {
+	if os.Getenv("VIMYT_DISCORD_APP_ID") != "" {
+		return
+	}
+	s.mu.Lock()
+	if id != s.appID {
+		s.appID = id
+		if s.conn != nil {
+			s.clearActivity()
+			s.conn.Close()
+			s.conn = nil
+		}
+		s.lastSig = ""
+	}
+	s.mu.Unlock()
+}
+
+// SetShowButton toggles the "Listen on YT Music" button.
+func (s *Server) SetShowButton(on bool) {
+	s.mu.Lock()
+	s.showButton = on
+	s.lastSig = "" // force a resend so the button appears/disappears now
+	s.mu.Unlock()
+}
+
+// Close tears down the server and clears the activity.
+func (s *Server) Close() {
+	s.quit()
+	<-s.quitDone
+}
+
+func (s *Server) run(ctx context.Context) {
+	defer close(s.quitDone)
+
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.mu.Lock()
+			if s.conn != nil {
+				s.clearActivity()
+				s.conn.Close()
+				s.conn = nil
+			}
+			s.mu.Unlock()
+			return
+		case <-ticker.C:
+			s.tick()
+		}
+	}
+}
+
+func (s *Server) tick() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.enabled || s.appID == "" {
+		if s.conn != nil {
+			s.clearActivity()
+		}
+		s.lastSig = ""
+		return
+	}
+
+	if s.conn == nil {
+		// Throttle reconnect attempts to once every ~15s.
+		if time.Since(s.lastConnTry) < 15*time.Second {
+			return
+		}
+		s.lastConnTry = time.Now()
+		if err := s.connect(); err != nil {
+			return
+		}
+	}
+
+	act := s.activityFor(s.player.Status())
+	if act == nil {
+		if s.lastSig != "cleared" {
+			s.clearActivity()
+			s.lastSig = "cleared"
+		}
+		return
+	}
+
+	sig := s.signature(act)
+	// Resend if anything meaningful changed, or if the real position drifted
+	// from the bar we last published (e.g. after a seek).
+	drift := false
+	if act.Timestamps != nil {
+		if d := act.Timestamps.Start - s.lastStart; d > 3000 || d < -3000 {
+			drift = true
+		}
+	}
+	if sig == s.lastSig && !drift {
+		return
+	}
+
+	if err := s.setActivity(act); err != nil {
+		// Connection likely dropped; drop it and retry later.
+		s.conn.Close()
+		s.conn = nil
+		s.lastSig = ""
+		return
+	}
+	s.lastSig = sig
+	if act.Timestamps != nil {
+		s.lastStart = act.Timestamps.Start
+	} else {
+		s.lastStart = 0
+	}
+}
+
+func (s *Server) activityFor(st model.PlayerStatus) *activity {
+	if st.Track == nil || st.State == model.Stopped {
+		return nil
+	}
+	t := st.Track
+	a := &activity{
+		Type:    activityListening,
+		Details: t.Title,
+		State:   t.Artist,
+	}
+
+	art := artURL(t)
+	if art != "" || t.Album != "" {
+		largeText := t.Album
+		if largeText == "" {
+			largeText = t.Title
+		}
+		a.Assets = &assets{LargeImage: art, LargeText: largeText}
+	}
+
+	// Progress bar: only while actually playing and with a known duration.
+	if st.State == model.Playing && t.Duration > 0 {
+		now := time.Now()
+		start := now.Add(-st.Position)
+		a.Timestamps = &timestamps{
+			Start: start.UnixMilli(),
+			End:   start.Add(t.Duration).UnixMilli(),
+		}
+	}
+
+	if s.showButton && t.ID != "" {
+		a.Buttons = []button{{
+			Label: "Listen on YT Music",
+			URL:   "https://music.youtube.com/watch?v=" + t.ID,
+		}}
+	}
+	return a
+}
+
+// signature returns a string that changes only when a resend is warranted.
+func (s *Server) signature(a *activity) string {
+	hasBar := a.Timestamps != nil
+	return fmt.Sprintf("%s|%s|%t|%t", a.Details, a.State, hasBar, len(a.Buttons) > 0)
+}
+
+func artURL(t *model.Track) string {
+	if t.ThumbnailURL != "" {
+		return t.ThumbnailURL
+	}
+	if t.ID != "" {
+		return fmt.Sprintf("https://img.youtube.com/vi/%s/hqdefault.jpg", t.ID)
+	}
+	return ""
+}
+
+// --- IPC plumbing ---
+
+func (s *Server) connect() error {
+	conn, err := dialDiscord()
+	if err != nil {
+		return err
+	}
+	// Handshake.
+	hs, _ := json.Marshal(map[string]any{"v": 1, "client_id": s.appID})
+	if err := writeFrame(conn, opHandshake, hs); err != nil {
+		conn.Close()
+		return err
+	}
+	if _, _, err := readFrame(conn); err != nil {
+		conn.Close()
+		return err
+	}
+	s.conn = conn
+	s.lastSig = ""
+	return nil
+}
+
+func (s *Server) setActivity(a *activity) error {
+	payload := map[string]any{
+		"cmd": "SET_ACTIVITY",
+		"args": map[string]any{
+			"pid":      os.Getpid(),
+			"activity": a,
+		},
+		"nonce": strconv.FormatInt(time.Now().UnixNano(), 10),
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	return writeFrame(s.conn, opFrame, data)
+}
+
+func (s *Server) clearActivity() {
+	if s.conn == nil {
+		return
+	}
+	payload := map[string]any{
+		"cmd": "SET_ACTIVITY",
+		"args": map[string]any{
+			"pid":      os.Getpid(),
+			"activity": nil,
+		},
+		"nonce": strconv.FormatInt(time.Now().UnixNano(), 10),
+	}
+	data, _ := json.Marshal(payload)
+	_ = writeFrame(s.conn, opFrame, data)
+}
+
+// dialDiscord locates and connects to the discord-ipc-N unix socket.
+func dialDiscord() (net.Conn, error) {
+	base := os.Getenv("XDG_RUNTIME_DIR")
+	if base == "" {
+		base = os.TempDir()
+	}
+	dirs := []string{
+		base,
+		filepath.Join(base, "app", "com.discordapp.Discord"),
+		filepath.Join(base, "snap.discord"),
+		"/tmp",
+	}
+	for _, d := range dirs {
+		for i := 0; i < 10; i++ {
+			p := filepath.Join(d, fmt.Sprintf("discord-ipc-%d", i))
+			if c, err := net.Dial("unix", p); err == nil {
+				return c, nil
+			}
+		}
+	}
+	return nil, errors.New("discord ipc socket not found")
+}
+
+func writeFrame(c net.Conn, op uint32, payload []byte) error {
+	buf := make([]byte, 8+len(payload))
+	binary.LittleEndian.PutUint32(buf[0:4], op)
+	binary.LittleEndian.PutUint32(buf[4:8], uint32(len(payload)))
+	copy(buf[8:], payload)
+	_, err := c.Write(buf)
+	return err
+}
+
+func readFrame(c net.Conn) (uint32, []byte, error) {
+	header := make([]byte, 8)
+	if _, err := io.ReadFull(c, header); err != nil {
+		return 0, nil, err
+	}
+	op := binary.LittleEndian.Uint32(header[0:4])
+	ln := binary.LittleEndian.Uint32(header[4:8])
+	data := make([]byte, ln)
+	if _, err := io.ReadFull(c, data); err != nil {
+		return 0, nil, err
+	}
+	return op, data, nil
+}

--- a/internal/model/session.go
+++ b/internal/model/session.go
@@ -50,6 +50,9 @@ type Session struct {
 	LoopCount         int               `json:"loop_count"`      // remaining loops (0 = infinite)
 	LoopTotal         int               `json:"loop_total"`      // original loop count for display
 	Theme             map[string]string `json:"theme,omitempty"` // custom color theme overrides
+	DiscordAppID      string            `json:"discord_app_id"`  // user's Discord application ID (empty = RPC not set up)
+	DiscordRPC        bool              `json:"discord_rpc"`     // publish Discord Rich Presence
+	DiscordButton     bool              `json:"discord_button"`  // show "Listen on YT Music" button in RPC
 }
 
 func sessionPath() (string, error) {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -8,6 +8,7 @@ type Track struct {
 	ID           string
 	Title        string
 	Artist       string
+	Album        string
 	Duration     time.Duration
 	StreamURL    string
 	ThumbnailURL string

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/Sadoaz/vimyt/internal/discord"
 	"github.com/Sadoaz/vimyt/internal/model"
 	"github.com/Sadoaz/vimyt/internal/player"
 	"github.com/Sadoaz/vimyt/internal/youtube"
@@ -117,6 +118,13 @@ type App struct {
 	autoFocusQueue      bool  // focus queue panel when playing a track
 	queueAfterCurrent   bool
 	cookieBrowser       string          // browser for yt-dlp cookie auth ("" = off)
+	discordAppID        string          // user's Discord application ID ("" = RPC not set up)
+	discordRPC          bool            // publish Discord Rich Presence
+	discordButton       bool            // show "Listen on YT Music" button in RPC
+	discord             *discord.Server // Discord Rich Presence server (nil if disabled)
+	showDiscordSetup    bool            // Discord setup sub-view active
+	discordSetupInp     textinput.Model // text input for the Discord app ID
+	discordSetupConfirm bool            // "Discord RPC Set up!" dialog awaiting Enter
 	showSettings        bool            // settings overlay visible
 	settingsCur         int             // cursor in settings list
 	settingsImporting   bool            // true when URL input is active in settings
@@ -243,7 +251,7 @@ func checkDeps() string {
 }
 
 // New creates a new App model, restoring previous session state.
-func New(plStore *model.PlaylistStore, p *player.Player) App {
+func New(plStore *model.PlaylistStore, p *player.Player, dc *discord.Server) App {
 	ci := textinput.New()
 	ci.Prompt = ":"
 	ci.CharLimit = 10
@@ -286,6 +294,12 @@ func New(plStore *model.PlaylistStore, p *player.Player) App {
 	sfInp.CharLimit = 40
 	sfInp.Cursor.SetMode(cursor.CursorStatic)
 	hi.Cursor.SetMode(cursor.CursorStatic)
+
+	dsi := textinput.New()
+	dsi.Prompt = "App ID: "
+	dsi.Placeholder = "1387426000000000000"
+	dsi.CharLimit = 32
+	dsi.Cursor.SetMode(cursor.CursorStatic)
 
 	sessionExists := model.SessionExists()
 	sess := model.LoadSession()
@@ -401,7 +415,18 @@ func New(plStore *model.PlaylistStore, p *player.Player) App {
 		loopCount:            sess.LoopCount,
 		loopTotal:            sess.LoopTotal,
 		theme:                ThemeFromMap(sess.Theme),
+		discordAppID:         sess.DiscordAppID,
+		discordRPC:           sess.DiscordRPC,
+		discordButton:        sess.DiscordButton,
+		discord:              dc,
+		discordSetupInp:      dsi,
 		prefetchNextIdx:      -1,
+	}
+	// Apply persisted Discord Rich Presence settings to the server.
+	if dc != nil {
+		dc.SetAppID(app.discordAppID)
+		dc.SetShowButton(app.discordButton)
+		dc.SetEnabled(app.discordRPC)
 	}
 	// Apply cookie browser setting to youtube package
 	youtube.SetCookieBrowser(app.cookieBrowser)

--- a/internal/tui/playback.go
+++ b/internal/tui/playback.go
@@ -241,6 +241,9 @@ func (a *App) saveSession() {
 		LoopCount:         a.loopCount,
 		LoopTotal:         a.loopTotal,
 		Theme:             a.theme.ToMap(),
+		DiscordAppID:      a.discordAppID,
+		DiscordRPC:        a.discordRPC,
+		DiscordButton:     a.discordButton,
 	}
 	if a.playlist.radioActive {
 		// Don't save radio as detail level — go back to list

--- a/internal/tui/settings.go
+++ b/internal/tui/settings.go
@@ -33,9 +33,15 @@ var settingsOptions = []struct {
 	{"Show Radio", "Show radio history panel below play history"},       // 12
 	{"Show Artists", "Show artists panel"},                              // 13
 	{"Colors", "Customize TUI colors"},                                  // 14
-	{"YT Auth", "Use browser cookies to access your private playlists"}, // 15
-	{"Import", "Import playlist from YouTube URL"},                      // 16
+	{"YT Auth", "Use browser cookies to access your private playlists"},           // 15
+	{"Import", "Import playlist from YouTube URL"},                                // 16
+	{"Set up Discord RPC", "Configure your own Discord application ID to enable Rich Presence"}, // 17 (name overridden once set up)
+	{"Discord Rich Presence", "Show current track as a Discord listening status"},                // 18
+	{"Show Listen on YTMusic Button In RPC", "Add a button linking to the track on music.youtube.com"}, // 19
 }
+
+// discordSetUp reports whether the user has configured a Discord application ID.
+func (a *App) discordSetUp() bool { return a.discordAppID != "" }
 
 // browserOptions is the cycle for the Auth Browser setting.
 var browserOptions = []string{"", "firefox", "chrome", "chromium", "brave", "edge"}
@@ -76,6 +82,12 @@ func (a *App) settingValue(idx int) bool {
 		return a.cookieBrowser != ""
 	case 16:
 		return false
+	case 17:
+		return false // Set up / Change Discord App ID — action, not a toggle
+	case 18:
+		return a.discordRPC
+	case 19:
+		return a.discordButton
 	}
 	return false
 }
@@ -149,6 +161,18 @@ func (a *App) toggleSetting(idx int) {
 	case 15:
 		a.cycleBrowser(1)
 	case 16:
+	case 17:
+		// Set up / Change Discord App ID — opens its own screen, no toggle.
+	case 18:
+		a.discordRPC = !a.discordRPC
+		if a.discord != nil {
+			a.discord.SetEnabled(a.discordRPC)
+		}
+	case 19:
+		a.discordButton = !a.discordButton
+		if a.discord != nil {
+			a.discord.SetShowButton(a.discordButton)
+		}
 	}
 }
 
@@ -176,20 +200,21 @@ func (a *App) cycleBrowser(dir int) {
 
 // settingsFilteredIndices returns the indices of settings matching the filter.
 func (a *App) settingsFilteredIndices() []int {
-	if a.settingsFilter == "" {
-		indices := make([]int, len(settingsOptions))
-		for i := range settingsOptions {
-			indices[i] = i
-		}
-		return indices
-	}
-	filter := strings.ToLower(a.settingsFilter)
+	// The Discord RPC toggles (18, 19) stay hidden until the user has set up
+	// their own application ID.
+	setUp := a.discordSetUp()
 	var indices []int
+	filter := strings.ToLower(a.settingsFilter)
 	for i, opt := range settingsOptions {
-		if strings.Contains(strings.ToLower(opt.name), filter) ||
-			strings.Contains(strings.ToLower(opt.desc), filter) {
-			indices = append(indices, i)
+		if (i == 18 || i == 19) && !setUp {
+			continue
 		}
+		if a.settingsFilter != "" &&
+			!strings.Contains(strings.ToLower(opt.name), filter) &&
+			!strings.Contains(strings.ToLower(opt.desc), filter) {
+			continue
+		}
+		indices = append(indices, i)
 	}
 	return indices
 }
@@ -198,6 +223,11 @@ func (a App) updateSettings(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Handle color editor sub-view
 	if a.showColorEditor {
 		return a.updateColorEditor(msg)
+	}
+
+	// Handle Discord setup sub-view
+	if a.showDiscordSetup {
+		return a.updateDiscordSetup(msg)
 	}
 
 	// Handle settings search input
@@ -351,6 +381,10 @@ func (a App) updateSettings(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			a.settingsImportInput.Focus()
 			return a, nil
 		}
+		if realIdx == 17 { // Set up / Change Discord App ID
+			a.openDiscordSetup()
+			return a, nil
+		}
 		a.toggleSetting(realIdx)
 		return a, nil
 	case msg.String() == "l", msg.String() == "right":
@@ -367,6 +401,8 @@ func (a App) updateSettings(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case 15:
 			a.cycleBrowser(1)
 		case 16:
+		case 17:
+			a.openDiscordSetup()
 		default:
 			if !a.settingValue(realIdx) {
 				a.toggleSetting(realIdx)
@@ -385,6 +421,7 @@ func (a App) updateSettings(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case 15:
 			a.cycleBrowser(-1)
 		case 16:
+		case 17:
 		default:
 			if a.settingValue(realIdx) {
 				a.toggleSetting(realIdx)
@@ -404,6 +441,9 @@ var (
 func (a App) renderSettings() string {
 	if a.showColorEditor {
 		return a.renderColorEditor()
+	}
+	if a.showDiscordSetup {
+		return a.renderDiscordSetup()
 	}
 
 	boxW := min(max(a.width*2/3, 50), a.width-2)
@@ -439,8 +479,14 @@ func (a App) renderSettings() string {
 	for vi := scroll; vi < end; vi++ {
 		realIdx := filtered[vi]
 		opt := settingsOptions[realIdx]
+		name := opt.name
 		var toggle string
 		switch realIdx {
+		case 17:
+			toggle = actionStyle.Render("[>>>]")
+			if a.discordSetUp() {
+				name = "Change Discord App ID"
+			}
 		case 2:
 			if !a.loopTrack {
 				toggle = settingsOffStyle.Render("[OFF]")
@@ -467,7 +513,7 @@ func (a App) renderSettings() string {
 				toggle = settingsOffStyle.Render("[OFF]")
 			}
 		}
-		line := fmt.Sprintf("  %s  %-14s %s", toggle, opt.name, descStyle.Render(opt.desc))
+		line := fmt.Sprintf("  %s  %-14s %s", toggle, name, descStyle.Render(opt.desc))
 		line = ansi.Truncate(line, innerW, "")
 		if vi == a.settingsCur {
 			line = settingsCurStyle.Render(line)
@@ -497,6 +543,113 @@ func (a App) renderSettings() string {
 		overlayTitleStyle.Render("Settings") + "\n\n" + b.String(),
 	)
 	return box
+}
+
+// openDiscordSetup enters the Discord setup sub-view, prefilling the input with
+// the current app ID (empty on first setup).
+func (a *App) openDiscordSetup() {
+	a.showDiscordSetup = true
+	a.discordSetupConfirm = false
+	a.discordSetupInp.SetValue(a.discordAppID)
+	a.discordSetupInp.CursorEnd()
+	a.discordSetupInp.Focus()
+}
+
+// updateDiscordSetup handles keys in the Discord setup sub-view.
+func (a App) updateDiscordSetup(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// "Discord RPC Set up!" confirmation dialog — any Enter/Esc dismisses it.
+	if a.discordSetupConfirm {
+		switch {
+		case key.Matches(msg, keys.Quit) && msg.String() == "ctrl+c":
+			a.quit()
+			return a, tea.Quit
+		case key.Matches(msg, keys.Enter), key.Matches(msg, keys.Escape):
+			a.discordSetupConfirm = false
+			a.showDiscordSetup = false
+			return a, nil
+		}
+		return a, nil
+	}
+
+	switch {
+	case key.Matches(msg, keys.Quit) && msg.String() == "ctrl+c":
+		a.quit()
+		return a, tea.Quit
+	case key.Matches(msg, keys.Enter):
+		val := strings.TrimSpace(a.discordSetupInp.Value())
+		if val == "" {
+			return a, nil
+		}
+		wasSetUp := a.discordSetUp()
+		a.discordAppID = val
+		a.discordSetupInp.Blur()
+		if a.discord != nil {
+			a.discord.SetAppID(val)
+		}
+		// On first setup, Rich Presence and the button default to on.
+		if !wasSetUp {
+			a.discordRPC = true
+			a.discordButton = true
+			if a.discord != nil {
+				a.discord.SetEnabled(true)
+				a.discord.SetShowButton(true)
+			}
+		}
+		a.saveSession()
+		a.discordSetupConfirm = true
+		return a, nil
+	case key.Matches(msg, keys.Escape):
+		a.discordSetupInp.Blur()
+		a.showDiscordSetup = false
+		return a, nil
+	default:
+		var cmd tea.Cmd
+		a.discordSetupInp, cmd = a.discordSetupInp.Update(msg)
+		return a, cmd
+	}
+}
+
+// renderDiscordSetup renders the Discord setup tutorial + app ID input.
+func (a App) renderDiscordSetup() string {
+	boxW := min(max(a.width*2/3, 50), a.width-2)
+
+	if a.discordSetupConfirm {
+		okStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("82")).Bold(true)
+		body := okStyle.Render("Discord RPC Set up!") + "\n\n" +
+			lipgloss.NewStyle().Foreground(lipgloss.Color("243")).Render("  Enter = OK")
+		return overlayBorderStyle.Width(boxW).Render(
+			overlayTitleStyle.Render("Discord RPC") + "\n\n" + body,
+		)
+	}
+
+	innerW := boxW - 6
+	if innerW < 20 {
+		innerW = 20
+	}
+	descStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
+	stepStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
+
+	steps := []string{
+		"1. Open " + stepStyle.Render("https://discord.com/developers/applications"),
+		"2. Click " + stepStyle.Render("New Application") + ", name it (e.g. \"vimyt\"),",
+		"   and create it. The name shows as \"Listening to <name>\".",
+		"3. Open the app and copy its " + stepStyle.Render("Application ID"),
+		"   (General Information tab).",
+		"4. In Discord, enable " + stepStyle.Render("Settings > Activity Privacy >"),
+		"   " + stepStyle.Render("Share your detected activities") + ".",
+		"5. Paste the Application ID below and press Enter.",
+	}
+
+	var b strings.Builder
+	for _, s := range steps {
+		b.WriteString("  " + ansi.Truncate(s, innerW, "") + "\n")
+	}
+	b.WriteString("\n  " + a.discordSetupInp.View() + "\n")
+	b.WriteString("\n" + ansi.Truncate(descStyle.Render("  Enter = save  Esc = cancel"), innerW, ""))
+
+	return overlayBorderStyle.Width(boxW).Render(
+		overlayTitleStyle.Render("Set up Discord RPC") + "\n\n" + b.String(),
+	)
 }
 
 // updateColorEditor handles keys in the color editor sub-view.

--- a/internal/youtube/artist.go
+++ b/internal/youtube/artist.go
@@ -184,5 +184,8 @@ func fetchReleases(channelID string) ([]Album, error) {
 // Returns the album title and tracks.
 func FetchAlbumTracks(album Album) ([]model.Track, error) {
 	_, tracks, err := FetchPlaylist(album.URL)
+	for i := range tracks {
+		tracks[i].Album = album.Title
+	}
 	return tracks, err
 }

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/Sadoaz/vimyt/internal/discord"
 	"github.com/Sadoaz/vimyt/internal/model"
 	"github.com/Sadoaz/vimyt/internal/mpris"
 	"github.com/Sadoaz/vimyt/internal/player"
@@ -29,13 +30,18 @@ func main() {
 		}
 	}
 
+	// Discord Rich Presence. Starts disabled; the TUI enables it from the
+	// persisted session settings. Safe no-op if Discord is not running.
+	dc := discord.New(p, false, false, "")
+	defer dc.Close()
+
 	plStore, err := model.NewPlaylistStore()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading playlists: %v\n", err)
 		os.Exit(1)
 	}
 
-	app := tui.New(plStore, p)
+	app := tui.New(plStore, p, dc)
 	p2 := tea.NewProgram(app, tea.WithAltScreen())
 	if _, err := p2.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error running vimyt: %v\n", err)


### PR DESCRIPTION
Add Discord Rich Presence support so the currently playing track shows up as a "Listening to ..." status. The client speaks Discord's local IPC protocol directly over the discord-ipc-N unix socket, so it needs no third-party dependency: it polls the player once a second and pushes title, artist, album art, a progress bar, and an optional "Listen on YT Music" button.

RPC requires the user to configure their own Discord application ID through a setup screen in settings. Until an app ID is set, settings shows only a "Set up Discord RPC" action that opens a tutorial screen with an app ID input. Submitting it persists the ID, defaults RPC and the listen button to on, and shows a "Discord RPC Set up!" confirmation. Once configured, the RPC toggles unlock and the action renames to "Change Discord App ID". VIMYT_DISCORD_APP_ID still overrides if set.